### PR TITLE
v0.2/v0.3

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://localhost/alchemist
+DATABASE_URL=alchemist.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+alchemist.db
+.directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,29 @@ sudo: required
 dist: trusty
 language: rust
 cache:
-  - apt
+- apt
 env:
   global:
-    - PATH=$PATH:~/.cargo/bin
+  - PATH=$PATH:~/.cargo/bin
 addons:
   postgresql: '9.4'
-
-# run builds for all the trains (and more)
 rust:
-  - nightly
-  - beta
-  - stable
-
+- nightly-2016-05-08
+- nightly
+- beta
+- stable
 matrix:
   allow_failures:
-    - rust: stable
-    - rust: beta
-
+  - rust: nightly
+  - rust: stable
+  - rust: beta
 script:
-  - cargo install diesel_cli
-  - diesel setup
-  - diesel migration run
-  - cargo build
-
+- cargo install diesel_cli
+- diesel setup
+- diesel migration run
+- cargo build
 notifications:
   email: false
+  slack:
+    rooms:
+      secure: lxJi2t2f7kPd6q0YKRZHl0qh3ZKYx2jC37QFdJU+n37XZNV+ZA1AquAp25yxhKeZnp4S9LD7/Kd8NdRa2Ld9r4KkGBKYuw+dS9Hc5y09TugovhT6KVypa2i9Fj9pbINjdC4t+3ixSccnEcW/gxfAJsYlXIWGbVFcQebLI9QkSsrnBW95YF6j3uvUgJYVDpPBnNyZFjkINUZQH1nWP4FfoSKJvVpo6GLXE5iAUZnhBa/fqgFyThbVeVdfBfU9t1XxMjsc5k1cvHCqS3p0ks/2yHLbqcrJlUjIa8i15YBxxKb8P6ggRlEDZxl3aykrmcjZAcCWT/51OgDrLsaDZ/wT4OEJ+UR3NorfbYLW2LKjjFLH29LaISM1jQXx5iyst5Agso327CCQ2+B1tHymkVBIeWzjarcmmkibn6UjFhbSi+T0dYgQks0HvCgufKHZ9gzTmRlLMaVb0OWavrUssEz4iP4ZZVB22I0+5hxJ/YDSNV43mHdTGLL+gi4Up6cRntkBD1weA/J1qAQLO0QOvMVf8fJ+q7seJP5Rg5ywbgFgpSWrAtEgL5evSQmXkznu8Ku/RCSXdFqd86XDlE/SzH1UWZDIn2H2IlzTlHnJbi9YprNW7hPLbqI2zMFG1NCa1yNKJ1N5Lcdtp04ljZMvLXkeiWoDhnS1BEozP7hhukDM/i0=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Alchemist"
-version = "0.1.1"
+version = "0.3.0"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 repository = "https://github.com/mgattozzi/Alchemist"
 homepage = "https://github.com/mgattozzi/Alchemist"
@@ -18,8 +18,8 @@ path = "src/bin/alchemist.rs"
 
 [dependencies]
 clap               = "*"
-diesel             = { git = "https://github.com/diesel-rs/diesel.git", features=["postgres"] }
-diesel_codegen     = { git = "https://github.com/diesel-rs/diesel.git", default-features = false, features=["nightly", "postgres"] }
+diesel             = { git = "https://github.com/diesel-rs/diesel.git", default-features = false, features=["sqlite"] }
+diesel_codegen     = { git = "https://github.com/diesel-rs/diesel.git", default-features = false, features=["nightly", "sqlite"] }
 dotenv             = "*"
 dotenv_macros      = "*"
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-#Alchemist
-##Unix Platform Agnostic Installation Tool
+<H1 align="center">Alchemist</H1>
+<p align="center">
+  <img src=https://avatars3.githubusercontent.com/u/19353789?v=3&s=200>
+</p>
+<H2 align="center">Unix Platform Agnostic Installation Tool</H2>
 
 
-Master:
+**Master:**
 
-[![Build Status](https://travis-ci.org/mgattozzi/Alchemist.svg?branch=master)](https://travis-ci.org/mgattozzi/Alchemist)
+[![Build Status](https://travis-ci.org/Alchemist-rs/Alchemist.svg?branch=master)](https://travis-ci.org/Alchemist-rs/Alchemist)
 
-Dev:
+**Dev:**
 
-[![Build Status](https://travis-ci.org/mgattozzi/Alchemist.svg?branch=dev)](https://travis-ci.org/mgattozzi/Alchemist)
+[![Build Status](https://travis-ci.org/Alchemist-rs/Alchemist.svg?branch=dev)](https://travis-ci.org/Alchemist-rs/Alchemist)
 
 ###Inspiration
 I was tired of having to search for what packages I have to use for what
@@ -44,25 +47,29 @@ and make it easy to install things regardless of your package manager.
   - Write tests! Unit tests and integration tests that can be run on a
     CI instance is a big plus and adds better code coverage!
 
-###Compiler Version
-Due to the nature of the Diesel library needing nightly
-that's the versionthat will be needed. At some point in
-the future I'll work on creating an installer to get it
-working on stable using Syntex. As of now though since
-this is far from production ready nightly is fine.
+###Slack
+We communicate using Slack using it as a central way to track issues
+etc. If you'd like to join us send an email to mgattozzi@gmail.com
+with the Subject Line [Slack Alchemist] and you'll get an invite.
 
-###Dependencies
+###Compiler Version
+Due to certain needed features we've pegged a specific version of the rust nightly compiler
+Currently using:
+
+```
+nightly-2016-05-08
+```
+
+###Native Library Dependencies
 
 For diesel:
 
 ```
-postgresql and it's dev libraries
+Sqlite3
 ```
 
-###Setup
-There is more to do here but this should just be as simple as run and
-done for the end user to get all setup. For now there are distribution
-specific setup scripts.
+###Dev Setup
+This will setup all the tools you need to get hacking away.
 
 ####Arch Linux
 To get setup for development run:
@@ -71,11 +78,9 @@ To get setup for development run:
 sh scripts/arch_setup.sh
 ```
 
-###Roadmap
-- v0.1.0
-  - [x] Create a mapping structure
-  - [x] Create Ubuntu to Arch Mappings
-  - [x] Create a db configuration file
-    - [x] Parse Configuratin
-    - [x] Configuration file structure
-  - [x] Arch Linux Support (including AUR)
+####Void Linux
+ To get setup for development run:
+
+ ```
+ sh scripts/void_setup.sh
+ ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -14,6 +14,8 @@
 
 ##Adding a distro:
 A few things need to happen in order to add a distro to Alchemist.
+Please note that anything with a varible (eg $distroname) is intended
+for you to replace.
 
 1. Open up an issue or comment on a request issue that you are adding
    support and include the following as checkboxes. Comment on the issue
@@ -25,13 +27,13 @@ A few things need to happen in order to add a distro to Alchemist.
    tool](https://github.com/diesel-rs/diesel/blob/master/diesel_cli) by
    running:
    ```
-   diesel migration generate add_$YOURDISTROHERE_support
+   diesel migration generate add_$distroname_support
    ```
 5. Using the up.sql file just created add the following to the file:
    ```
    ALTER TABLE packages ADD COLUMN $distroname TEXT NOT NULL DEFAULT '';
-   UPDATE packages SET $distroname=$packagename WHERE
-   id=$packageidnumber
+   UPDATE packages SET $distroname = '$packagename' WHERE
+   id = '$packageidnumber'
    --Keep repeating the UPDATE statment until all packages are added
    ```
    This will have to also include all of the names of the packages that
@@ -70,9 +72,10 @@ Open up the up.sql from the new migration and add the following:
 ```sql
 -- After packages include each of the distros located in the
 -- Packages struct in src/alchemy/models folder. You can
--- see what distros are in by checking the DB using psql
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES
-('postgresql',''postgresql','');
+-- see what distros are in by checking the DB using sqlite
+-- You'll also need to provide the correct id number for the db
+INSERT INTO packages(id,arch, aur, ubuntu, ubuntu_dev) VALUES
+(1,'postgresql',''postgresql','');
 
 -- Add more mappings to that list one for each distro in the order that
 -- you put for the first part of the statement. If no mapping exists you
@@ -88,7 +91,7 @@ DELETE FROM packages WHERE id > $ID_OF_PACKAGE_BEFORE_YOU_ADDED_NEW_ONES
 
 You can find out by running:
 ```
-psql -d alchemist
+sqlite3 alchemist.db
 SELECT * FROM packages;
 ```
 

--- a/migrations/20160428112233_packages_table/down.sql
+++ b/migrations/20160428112233_packages_table/down.sql
@@ -1,2 +1,1 @@
 DROP TABLE packages;
-DROP ROLE root;

--- a/migrations/20160428112233_packages_table/up.sql
+++ b/migrations/20160428112233_packages_table/up.sql
@@ -1,12 +1,9 @@
-CREATE ROLE root WITH LOGIN;
 CREATE TABLE packages (
-  id SERIAL PRIMARY KEY,
+  id int PRIMARY KEY NOT NULL,
   arch TEXT NOT NULL,
   aur TEXT NOT NULL,
   ubuntu TEXT NOT NULL,
   ubuntu_dev TEXT NOT NULL
 );
 
-GRANT SELECT ON packages TO root;
-
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('sudo','','sudo','');
+INSERT INTO packages(id,arch, aur, ubuntu, ubuntu_dev) VALUES (1,'sudo','','sudo','');

--- a/migrations/20160505170448_add-pkgs/down.sql
+++ b/migrations/20160505170448_add-pkgs/down.sql
@@ -1,1 +1,0 @@
-DELETE FROM packages WHERE id > 1;

--- a/migrations/20160505170448_add-pkgs/up.sql
+++ b/migrations/20160505170448_add-pkgs/up.sql
@@ -1,5 +1,0 @@
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('postgresql','','postgresql','');
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('postgresql-libs','','postgresql-contrib','');
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('sqlite','','sqlite3','libsqlite3-dev');
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('ncurses','','','libncurses5-dev');
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('ncurses','','','libncursesw5-dev');

--- a/migrations/20160511124741_add_void_support/down.sql
+++ b/migrations/20160511124741_add_void_support/down.sql
@@ -1,0 +1,12 @@
+CREATE TABLE new_packages (
+  id int PRIMARY KEY NOT NULL,
+  arch TEXT NOT NULL,
+  aur TEXT NOT NULL,
+  ubuntu TEXT NOT NULL,
+  ubuntu_dev TEXT NOT NULL
+);
+
+INSERT INTO new_packages SELECT id, arch, aur, ubuntu, ubuntu_dev FROM packages;
+
+DROP TABLE IF EXISTS packages;
+ALTER TABLE  new_packages RENAME TO packages;

--- a/migrations/20160511124741_add_void_support/up.sql
+++ b/migrations/20160511124741_add_void_support/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE packages ADD COLUMN void TEXT NOT NULL DEFAULT ''; UPDATE packages SET void = 'sudo' WHERE id = '1' --Keep repeating the UPDATE statment until all packages are added

--- a/scripts/void_setup.sh
+++ b/scripts/void_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #Install db depdendency
-sudo pacman -S sqlite3
+sudo xbps-install -S sqlite
 
 #Install multirust
 curl https://sh.rustup.rs -sSf | sh

--- a/src/alchemy/distro.rs
+++ b/src/alchemy/distro.rs
@@ -1,5 +1,10 @@
 use std::fs;
+use std::io::prelude::*;
+use std::fs::File;
+use std::string::String;
 
+#[derive(Debug)]
+///Enum used to represent Distribution used
 pub enum Distro {
     //Linux Distributions
     Arch,
@@ -7,6 +12,7 @@ pub enum Distro {
     Mint,
     Debian,
     Gentoo,
+    Void,
 
     //Berklee Unix Distributions
     Mac,
@@ -15,17 +21,44 @@ pub enum Distro {
     OpenBSD
 }
 
-///Returns what Distribution the user is using
-///If no possible match is found return a None
+/// Returns what Distribution the user is using
+/// If no possible match is found return a None
+///
+/// #Examples
+///
+/// ```
+/// let distro = which_distro();
+/// println!("{:?}",distro);
+/// ```
+///
+/// Currently only returns if the user is using
+/// Arch Linux and no other distribution
+///
 pub fn which_distro() -> Option<Distro> {
 
-    let arch= fs::metadata("/etc/arch-release");
+    //Open Proc and read into string the contents of it to be
+    //be checked below
+    let mut f = File::open("/proc/version")
+        .unwrap_or_else(|e| {
+            panic!("Failed to open /proc/version: {}",e)
+        });
+    let mut buffer = String::new();
+    let _unused = f.read_to_string(&mut buffer);
 
-    //Better way to do this?
-    if arch.is_ok() && arch.unwrap().is_file() {
-           return Some(Distro::Arch);
+    //Check for distros in Alphabetical order
+    if buffer.contains("arch") {
+        return Some(Distro::Arch);
+    } else if buffer.contains("void") {
+        return Some(Distro::Void);
     }
 
+
+    //Checks for Arch differently but only after the
+    //previous method trys by using /proc/version
+    let arch = fs::metadata("/etc/arch-release");
+    if arch.is_ok() && arch.unwrap().is_file() {
+        return Some(Distro::Arch)
+    }
     //No distro was found to match
     None
 }

--- a/src/alchemy/lib.rs
+++ b/src/alchemy/lib.rs
@@ -11,6 +11,7 @@ pub mod db;
 pub mod models;
 pub mod schema;
 pub mod arch;
+pub mod void;
 
 #[macro_use]
 extern crate diesel;

--- a/src/alchemy/models.rs
+++ b/src/alchemy/models.rs
@@ -1,4 +1,4 @@
-#[derive(Queryable, Debug)]
+#[derive(Queryable,PartialEq,PartialOrd,Eq,Ord,Hash,Debug)]
 /// Struct for a row in the Alchemist package table
 pub struct Package {
     /// Row Number makes it easy for migration
@@ -7,8 +7,25 @@ pub struct Package {
     pub arch: String,
     /// Arch Linux AUR Package
     pub aur: String,
+    /// Void Linux Package
+    pub void: String,
     /// Ubuntu Binary Packages
     pub ubuntu: String,
     /// Ubuntu Development Header Packages
     pub ubuntu_dev: String
+}
+
+impl Package {
+    ///Returns a Package with no data for instances of error handling
+    ///when connecting to the db and finding nothing
+    pub fn empty() -> Package {
+        Package {
+            id: 0,
+            arch: String::from(""),
+            aur : String::from(""),
+            void: String::from(""),
+            ubuntu: String::from(""),
+            ubuntu_dev: String::from(""),
+        }
+    }
 }

--- a/src/alchemy/void.rs
+++ b/src/alchemy/void.rs
@@ -1,0 +1,105 @@
+use std::process::Command;
+use std::collections::HashSet;
+
+use db;
+
+/// Installs Packages on Void Linux
+///
+/// #Examples
+///
+/// ```
+/// let mut packages: HashSet<&str> = HashSet::new();
+/// packages.push("sudo");
+/// packages.push("postgresql");
+/// void_install(packages);
+/// ```
+///
+pub fn void_install(packages: HashSet<String>) {
+    let void_packages = convert_to_void(packages);
+    if !void_packages.is_empty() {
+        xbps(void_packages);
+    }
+}
+
+///Convert package names from other distros to void
+fn convert_to_void(input_packages: HashSet<String>) -> HashSet<String> {
+    let results = db::pack_query(input_packages);
+    let mut xbps_converted: HashSet<String> = HashSet::new();
+
+    //Using the querys store into the HashSet the actual
+    //void package name for use later
+    for i in results {
+        //All querys will either be a string or '' in the db
+        //allowing us to use is_empty()
+        if !i.void.is_empty() {
+            xbps_converted.insert(i.void);
+        }
+    }
+
+    xbps_converted
+}
+
+//xbps specific functions
+
+/// Calls the xbps program to install packages
+///
+/// #Examples
+///
+/// ```
+/// let mut packages: HashSet<String> = HashSet::new();
+/// packages.push("sudo".to_owned());
+/// xbps(packages);
+/// ```
+///
+pub fn xbps(mut packages: HashSet<String>) {
+    let mut child = match Command::new("xbps-install")
+            .arg("-S")
+            .args(packages
+                  .drain()
+                  .collect::<Vec<String>>()
+                  .as_slice())
+            .spawn()
+    {
+        Ok(child) => child,
+        Err(e)    => panic!("Failed to execute child: {}",e),
+    };
+    let _unused = child.wait();
+}
+
+/// Calls the xbps-install program to refresh the package list
+///
+/// #Examples
+///
+/// ```
+/// refresh_list();
+/// ```
+///
+pub fn refresh_list() {
+    let mut child = match Command::new("xbps-install")
+            .arg("-Sy")
+            .spawn()
+    {
+        Ok(child) => child,
+        Err(e)    => panic!("Failed to execute child: {}",e),
+    };
+    let _unused = child.wait();
+}
+
+/// Calls the xbps-install program to upgrage all packages
+///
+/// #Examples
+///
+/// ```
+/// refresh_list();
+/// ```
+///
+pub fn upgrade_packages() {
+    let mut child = match Command::new("xbps-install")
+            .arg("-Syu")
+            .spawn()
+    {
+        Ok(child) => child,
+        Err(e)    => panic!("Failed to execute child: {}",e),
+    };
+    let _unused = child.wait();
+}

--- a/src/bin/alchemist.rs
+++ b/src/bin/alchemist.rs
@@ -1,5 +1,3 @@
-#![feature(plugin)]
-
 //External Crate Imports
 extern crate alchemy;
 extern crate clap;
@@ -9,12 +7,14 @@ extern crate diesel;
 use alchemy::su;
 use alchemy::distro::{Distro,which_distro};
 use alchemy::arch;
+use alchemy::void;
 
 //Clap Imports
 use clap::{App, Arg};
 
 //Std Lib Imports
 use std::process::exit;
+use std::collections::HashSet;
 
 fn main() {
 
@@ -56,13 +56,12 @@ fn main() {
     }
 
     //Prepare parse arguments of what to install
-    let mut package_inputs: Vec<&str> = Vec::new();
+    let mut package_inputs: HashSet<String> = HashSet::new();
     if let Some(p) = args.values_of("install") {
         for i in p {
-            package_inputs.push(i);
+            package_inputs.insert(i.to_string());
         }
-        let l2g = package_inputs.binary_search(&"pb");
-        if l2g.is_ok() {
+        if package_inputs.contains("pb") {
             println!("Looks like you're trying to turn lead into gold.");
             println!("That's not how this program works.");
             exit(0);
@@ -86,5 +85,13 @@ fn main() {
         Distro::FreeBSD => println!("FreeBSD"),
         Distro::NetBSD  => println!("NetBSD"),
         Distro::OpenBSD => println!("OpenBSD"),
+        Distro::Void    => {
+            if args.values_of("refresh").is_some() {
+                void::refresh_list();
+            } else if args.values_of("upgrade").is_some() {
+                void::upgrade_packages();
+            }
+            void::void_install(package_inputs);
+        },
     }
 }


### PR DESCRIPTION
v0.2.0

Due to the fact that I rewrote everything to use sqlite rather than
using postgresql I'm bumping the version to v0.2.0 rather than doing
a minor bump. The benefit of this though is that many people already
have sqlite installed as a dependency on their system. The other benefit
of it is that it's much lighter on the system in terms of resources
making it real nice for a command line tool like Alchemist. The jump to
v0.2.0 makes sense because everything was switched from Vecs to HashSets
breaking anyone using code based off this.

Release Notes:

- HashSets rather than Vecs for increased efficiency and fitting the needs
  of how Alchemist works
- SQLite rather than Postgresql for lighter dev dependencies and less
  resources being used on the system.

Upgrade

* Error Fixes, Warning Suppression, and Error Handling

Adds better error handling for DB connections when they aren't found
Fixes errors in building the code because of mismatched brackets
Supresses warnings from AUR Enum for unused parts of it
Adds empty helper method to the Package type to create a null version

v0.3.0

Add Void Linux Support
Change how distro checking works
Various administrative tasks and doc updates